### PR TITLE
[hotfix/fix-buildpack-healthchecker-err] paketo buildpacks health checker 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,14 +40,8 @@ dependencyManagement {
 bootBuildImage {
     builder = "docker.io/paketobuildpacks/builder-jammy-base"
     imageName = "zipbob-${project.name}"
-    environment = [
-            "BP_JVM_VERSION": "17.*",
-            "BP_HEALTH_CHECKER_ENABLED": "true",
-    ]
-    buildpacks = [
-            "urn:cnb:builder:paketo-buildpacks/java",
-            "gcr.io/paketo-buildpacks/health-checker:latest"
-    ]
+    environment = ["BP_JVM_VERSION" : "17.*"]
+
     docker {
         publishRegistry {
             url = project.findProperty("registryUrl")


### PR DESCRIPTION
## paketo buildpacks health checker 제거

### 개요
Paketo Buildpacks의 헬스 체커(Health Checker)를 활용해 네이티브 빌드팩 이미지를 생성하는 과정에서 에러가 발생하는 문제가 확인되었습니다.

### 주요 내용
- [x] paketo buildpacks health checker 제거

### 참고 사항
- 이에 따라 docker-compose 로직도 변경하였습니다. [변경사항 commit](https://github.com/Kakao-Tech-Bootcamp-Team2/zipbob-deployment/commit/23636ebf60361bab54ae81e27f8df4e89ea9f71c)

### 추가 내용
